### PR TITLE
GitHub Actions: Add upload  artifact step

### DIFF
--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -32,6 +32,12 @@ jobs:
         cd .. 
         # Run Hugo
         hugo -D
+        
+    - name: Upload website for manual inspection
+      uses: actions/upload-artifact@v1
+      with:
+        name: website
+        path: public
 
     - name: Deploy
       if: github.event_name == 'push' && (github.ref == 'refs/heads/source')


### PR DESCRIPTION
This is useful to check the content of the website before actual deploying, a sort of hackish "staging website".